### PR TITLE
Fix: Add cname to deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           publish_dir: ./build
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          cname: jmcdsn.com


### PR DESCRIPTION
Automatically adds the CNAME to the repo so the site doesn't go down after a deploy.