### PR TITLE
Fix: Render blocking CSS

### DIFF
--- a/src/site/_includes/layouts/default.njk
+++ b/src/site/_includes/layouts/default.njk
@@ -4,17 +4,37 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-		<link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicons/apple-touch-icon.png">
+
+		<!-- Preload / Preconnect -->
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link rel="preconnect" href="https://unpkg.com" crossorigin>
+		<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" />
+		<link rel="preload" as="style" href="https://unpkg.com/prismjs@1.23.0/themes/prism-tomorrow.css" />
+
+		<!-- Icons / Theme -->
+		<link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicons/favicon-16x16.png">
     <link rel="manifest" href="/assets/images/favicons/manifest.json">
     <link rel="mask-icon" href="/assets/images/favicons/safari-pinned-tab.svg" color="#f39c12">
     <meta name="theme-color" content="#f39c12">
 
-		<link rel="stylesheet" href="https://unpkg.com/prismjs@1.23.0/themes/prism-tomorrow.css">
-		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap">
+		<!-- Async load fonts -->
+		<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" media="print" onload="this.media='all'" />
+		<noscript>
+			<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Jost:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" />
+		</noscript>
+
+		<!-- Async load code styles -->
+		<link rel="stylesheet" href="https://unpkg.com/prismjs@1.23.0/themes/prism-tomorrow.css" media="print" onload="this.media='all'" />
+		<noscript>
+			<link rel="stylesheet" href="https://unpkg.com/prismjs@1.23.0/themes/prism-tomorrow.css" />
+		</noscript>
+
+		<!-- Load site main styles -->
     <link rel="stylesheet" href="/assets/css/index.css">
+
+		<!-- SEO -->
     {% include "seo.njk" %}
   </head>
   <body class="{% if bodyClass %}{{ bodyClass }}{% endif %}">


### PR DESCRIPTION
PageSpeed insights audit:
![developers google com_speed_pagespeed_insights__url=https%3A%2F%2Fjmcdsn com tab=mobile(iPad Pro)](https://user-images.githubusercontent.com/8181366/119571379-e45ca700-bd76-11eb-9183-37d05584bee4.png)

Hopefully this should fix those particular issues. Since fonts and code styles aren't 100% needed at load, should be OK to async for more performance. Lighthouse audit locally says it should help.